### PR TITLE
Add Roborock Qrevo S5V to tested vacuums

### DIFF
--- a/docs/tested_vacuums.md
+++ b/docs/tested_vacuums.md
@@ -14,6 +14,7 @@ The following vacuums are confirmed working:
 - Roborock S7 MaxV
 - Roborock S8 Pro Ultra (a70)
 - Roborock Saros 10R
+- Roborock Qrevo S5V
 - QRevo MaxV
 - QRevo Master
 


### PR DESCRIPTION
**Fully working** with the caveat of during on boarding I had to add a user input pause before [Line 574](https://github.com/Python-roborock/local_roborock_server/blob/6dd672933ade24f094373cbf2508380dbb8619b4/start_onboarding.py#L574 ) to allow me to change my wifi or I'd get 
```
Sending cfgwifi onboarding packet...
HELLO_RESP_CMD=17
HELLO_RESP_JSON={"id":1,"method":"hello","params":{"sdks":{"roborock":"02"},"key":"...."}}
TOKEN_S=....
TOKEN_T=...
WIFI_BODY_SENT=..
WIFI_RESP_CMD=...
WIFI_RESP_HEX=...
Reconnect this machine to your normal Wi-Fi. The script will poll the main server every 5 seconds for up to 5 minutes.
Error: <urlopen error [Errno -2] Name or service not known>
```

This was using Fedora 43.

Thank you for making this, I'm much happier now its off the internet!