### PR TITLE
Add Roborock G30U to tested vacuums

### DIFF
--- a/docs/tested_vacuums.md
+++ b/docs/tested_vacuums.md
@@ -13,7 +13,7 @@ The following vacuums are confirmed working:
 
 - Roborock S7 MaxV
 - Roborock S8 Pro Ultra (a70)
-- Roborock Saros 10R
+- Roborock Saros 10R / G30U
 - Roborock Qrevo S5V
 - QRevo MaxV
 - QRevo Master


### PR DESCRIPTION
### What Changed
- Added Roborock G30U (variant of Saros 10R) to tested vacuums.

Both the vacuum and the dock are properly enumerated in Home Assistant.

roborock.vacuum.a231, Firmware: 02.52.32
roborock.vacuum.a231 Dock (16), Firmware: 02.52.32