### PR TITLE
Learn unknown device MQTT credentials on first connect

### DIFF
--- a/src/roborock_local_server/bundled_backend/mqtt_tls_proxy_server/server.py
+++ b/src/roborock_local_server/bundled_backend/mqtt_tls_proxy_server/server.py
@@ -224,6 +224,13 @@ class MqttTlsProxy:
                 )
                 if recovered_device is not None:
                     return True, "device_mqtt_recovered", info
+            if auth_reason == "unknown_device_mqtt_username":
+                learned_device = self.runtime_credentials.learn_device_mqtt_credentials(
+                    username=username,
+                    password=password,
+                )
+                if learned_device is not None:
+                    return True, "device_mqtt_learned", info
 
         return False, "invalid_mqtt_credentials", info
 

--- a/src/roborock_local_server/bundled_backend/shared/runtime_credentials.py
+++ b/src/roborock_local_server/bundled_backend/shared/runtime_credentials.py
@@ -653,6 +653,25 @@ class RuntimeCredentialsStore:
                 return dict(device)
         return None
 
+    def learn_device_mqtt_credentials(self, *, username: str, password: str) -> dict[str, str] | None:
+        normalized_username = _clean_str(username)
+        normalized_password = _clean_str(password)
+        if not normalized_username or not normalized_password:
+            return None
+        with self._lock:
+            candidates = [
+                d for d in self._devices
+                if not _clean_str(d.get("device_mqtt_usr")) and _clean_str(d.get("did"))
+            ]
+            if len(candidates) != 1:
+                return None
+            device = candidates[0]
+            device["device_mqtt_usr"] = normalized_username
+            device["device_mqtt_pass"] = normalized_password
+            device["updated_at"] = utcnow_iso()
+            self._save_locked()
+            return dict(device)
+
     def recovery_pending_devices(self) -> list[dict[str, str]]:
         with self._lock:
             pending = [


### PR DESCRIPTION
My Saros 10R ignores bootstrap credentials from nc_prepare (don't know why...) and connects to MQTT using its own device credentials. The server rejects the connection because device_mqtt_usr is empty, and there's no way to identify it- record_mqtt_topic only runs after authentication succeeds.

This PR adds a fallback. When authentication returns unknown_device_mqtt_username, if exactly one device has an empty mqtt_usr and a non-empty did, it assigns the credentials from the CONNECT packet. It does nothing if there are 0 or 2 or more candidates.

I'm not sure this is the right approach, but it did unblock my setup. 

Relates to #19.